### PR TITLE
Add unbounded matching

### DIFF
--- a/FuzzyAutocomplete/DVTTextCompletionSession+FuzzyAutocomplete.m
+++ b/FuzzyAutocomplete/DVTTextCompletionSession+FuzzyAutocomplete.m
@@ -261,7 +261,7 @@ static char filteredCompletionCacheKey;
     NSMutableDictionary *filteredCompletionCache = objc_getAssociatedObject(self, &filteredCompletionCacheKey);
     if (!filteredCompletionCache) {
         filteredCompletionCache = [[NSMutableDictionary alloc] init];
-        objc_setAssociatedObject(self, &filteredCompletionCacheKey, filteredCompletionCache, OBJC_ASSOCIATION_RETAIN);
+        objc_setAssociatedObject(self, &filteredCompletionCacheKey, filteredCompletionCache, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
     NSArray *completionsForLetter = [filteredCompletionCache objectForKey:letter];
     if (!completionsForLetter) {


### PR DESCRIPTION
Adds unbounded fuzzy matching as per #7.

This PR both adds unbounded fuzzy matching and improves performance by ~40% by parallelising the matching and scoring process.

A combination of techniques were attempted, initially trying to use `NSEnumerationConcurrent` and serial queues for mutating the list, but it seems the internal DVTMergedSortArray does not like concurrent enumeration.

Initially, creating subarrays to work off worked alright, but since I wanted to eliminate the array creation, I tried striding, which was faster, but ended up with segmenting work in chunks for better cache locality.
