### PR TITLE
Remove log (at least in production)

### DIFF
--- a/FuzzyAutocomplete/FuzzyAutocomplete.m
+++ b/FuzzyAutocomplete/FuzzyAutocomplete.m
@@ -10,9 +10,4 @@
 
 @implementation FuzzyAutocomplete
 
-+ (void)pluginDidLoad:(NSBundle *)plugin
-{
-    ALog(@"Plugin loaded");
-}
-
 @end


### PR DESCRIPTION
Plugin shouldn't be logging stuff out in production,
as it adds unexpected behavior to commands like `xcodebuild`
