### PR TITLE
Adds the UUID for the App Store version of Xcode 5.1

### DIFF
--- a/FuzzyAutocomplete/FuzzyAutocomplete-Info.plist
+++ b/FuzzyAutocomplete/FuzzyAutocomplete-Info.plist
@@ -24,6 +24,7 @@
 	<string>1.5</string>
 	<key>DVTPlugInCompatibilityUUIDs</key>
 	<array>
+		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
 		<string>640F884E-CE55-4B40-87C0-8869546CAB7A</string>
 		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
 	</array>


### PR DESCRIPTION
It looks like the UUID for the App Store version of Xcode 5.1 is different from the beta. The new UUID was taken from the [Alcatraz patch](https://github.com/supermarin/Alcatraz/commit/0e60f424b13f2d46db4315b5926f487b8981fd62)
