### PR TITLE
Fix an infinite loop in OS X 10.10.2 (14C94b)

### DIFF
--- a/FuzzyAutocomplete/FuzzyAutocomplete.m
+++ b/FuzzyAutocomplete/FuzzyAutocomplete.m
@@ -62,7 +62,16 @@
 }
 
 + (void) menuDidChange: (NSNotification *) notification {
+    [[NSNotificationCenter defaultCenter] removeObserver: self
+                                                    name: NSMenuDidChangeItemNotification
+                                                  object: nil];
+
     [self createMenuItem];
+    
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(menuDidChange:)
+                                                 name: NSMenuDidChangeItemNotification
+                                               object: nil];
 }
 
 + (void)createMenuItem {
@@ -71,9 +80,6 @@
     NSMenuItem * editorMenuItem = [[NSApp mainMenu] itemWithTitle: @"Editor"];
 
     if (editorMenuItem && ![editorMenuItem.submenu itemWithTitle: name]) {
-        [[NSNotificationCenter defaultCenter] removeObserver: self
-                                                        name: NSMenuDidChangeItemNotification
-                                                      object: nil];
         
         NSMenuItem * fuzzyItem = [[NSMenuItem alloc] initWithTitle: name
                                                             action: NULL
@@ -101,11 +107,6 @@
         } else {
             [editorMenuItem.submenu insertItem: fuzzyItem atIndex: menuIndex];
         }
-        
-        [[NSNotificationCenter defaultCenter] addObserver: self
-                                                 selector: @selector(menuDidChange:)
-                                                     name: NSMenuDidChangeItemNotification
-                                                   object: nil];
     }
 }
 

--- a/FuzzyAutocomplete/FuzzyAutocomplete.m
+++ b/FuzzyAutocomplete/FuzzyAutocomplete.m
@@ -71,6 +71,10 @@
     NSMenuItem * editorMenuItem = [[NSApp mainMenu] itemWithTitle: @"Editor"];
 
     if (editorMenuItem && ![editorMenuItem.submenu itemWithTitle: name]) {
+        [[NSNotificationCenter defaultCenter] removeObserver: self
+                                                        name: NSMenuDidChangeItemNotification
+                                                      object: nil];
+        
         NSMenuItem * fuzzyItem = [[NSMenuItem alloc] initWithTitle: name
                                                             action: NULL
                                                      keyEquivalent: @""];

--- a/FuzzyAutocomplete/FuzzyAutocomplete.m
+++ b/FuzzyAutocomplete/FuzzyAutocomplete.m
@@ -102,6 +102,10 @@
             [editorMenuItem.submenu insertItem: fuzzyItem atIndex: menuIndex];
         }
         
+        [[NSNotificationCenter defaultCenter] addObserver: self
+                                                 selector: @selector(menuDidChange:)
+                                                     name: NSMenuDidChangeItemNotification
+                                                   object: nil];
     }
 }
 


### PR DESCRIPTION
It seems adding a menu item will fire the NSMenuDidChangeItemNotification in 10.10.2 (14C94b), which will result in an infinite loop. Remove the observer before adding the item should be good to fix this.