### PR TITLE
WIP: Non-blocking filtering

### DIFF
--- a/FuzzyAutocomplete/DVTTextCompletionSession+FuzzyAutocomplete.m
+++ b/FuzzyAutocomplete/DVTTextCompletionSession+FuzzyAutocomplete.m
@@ -367,18 +367,21 @@
         NSString *prefix = [self valueForKey:@"_filteringPrefix"];
         // Let the original handler deal with the zero letter case
         if (!prefix || prefix.length == 0) {
-            [self._fa_resultsStack removeAllObjects];
-            
-            NSTimeInterval start = [NSDate timeIntervalSinceReferenceDate];
-            [self _fa_setFilteringPrefix:prefix forceFilter:self._fa_forceFilter];
-            if (![FASettings currentSettings].showInlinePreview) {
-                [self._inlinePreviewController hideInlinePreviewWithReason: 0x0];
-            }
-            self.fa_filteringTime = [NSDate timeIntervalSinceReferenceDate] - start;
-            
-            if ([FASettings currentSettings].showTiming) {
-                [self._listWindowController _updateCurrentDisplayState];
-            }
+            dispatch_on_main(^{
+                [self._fa_resultsStack removeAllObjects];
+                
+                NSTimeInterval start = [NSDate timeIntervalSinceReferenceDate];
+                [self _fa_setFilteringPrefix:prefix forceFilter:self._fa_forceFilter];
+                if (![FASettings currentSettings].showInlinePreview) {
+                    [self._inlinePreviewController hideInlinePreviewWithReason: 0x0];
+                }
+                self.fa_filteringTime = [NSDate timeIntervalSinceReferenceDate] - start;
+                
+                if ([FASettings currentSettings].showTiming) {
+                    [self._listWindowController _updateCurrentDisplayState];
+                }
+
+            });
             return;
         }
         


### PR DESCRIPTION
This PR moves the fuzzy matching off the main thread for much improved responsiveness. It also only executes the fuzzy matching after 50ms of no typing activity to decrease the number of searches significantly which should save battery life.

I haven't used it enough to make sure it's stable, would like to have people help me test this particular branch.

* [ ] Add ability to configure delay