### PR TITLE
Xcode 6.3 compatibility

### DIFF
--- a/FuzzyAutocomplete/FuzzyAutocomplete-Info.plist
+++ b/FuzzyAutocomplete/FuzzyAutocomplete-Info.plist
@@ -30,6 +30,7 @@
 		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
 		<string>640F884E-CE55-4B40-87C0-8869546CAB7A</string>
 		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
+		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
 	</array>
 	<key>FAReportIssueURL</key>
 	<string>https://github.com/FuzzyAutocomplete/FuzzyAutocompletePlugin/issues</string>

--- a/XcodeHeaders/DVTCompletingTextView.h
+++ b/XcodeHeaders/DVTCompletingTextView.h
@@ -121,7 +121,7 @@
 - (id)accessibilityAttributeValue:(id)arg1;
 
 // Remaining properties
-@property(retain) id <DVTCompletingTextViewDelegate> delegate; // @dynamic delegate;
+@property(assign) id <DVTCompletingTextViewDelegate> delegate; // @dynamic delegate;
 
 @end
 


### PR DESCRIPTION
- Add compatibility UUID
- Change delegate property to `(assign)` in header file (inherited as `assign` from `NSText`)