### PR TITLE
Add UDID for Xcode 6.2 GM / App Store release

### DIFF
--- a/FuzzyAutocomplete/FuzzyAutocomplete-Info.plist
+++ b/FuzzyAutocomplete/FuzzyAutocomplete-Info.plist
@@ -31,6 +31,7 @@
 		<string>640F884E-CE55-4B40-87C0-8869546CAB7A</string>
 		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
 		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
+		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 	</array>
 	<key>FAReportIssueURL</key>
 	<string>https://github.com/FuzzyAutocomplete/FuzzyAutocompletePlugin/issues</string>


### PR DESCRIPTION
$ defaults read /Applications/Xcode.app/Contents/Info
DVTPlugInCompatibilityUUID
A16FF353-8441-459E-A50C-B071F53F51B7