### PR TITLE
add xcode 6.3.2 uuid

### DIFF
--- a/FuzzyAutocomplete/FuzzyAutocomplete-Info.plist
+++ b/FuzzyAutocomplete/FuzzyAutocomplete-Info.plist
@@ -33,6 +33,7 @@
 		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
 		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
+		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
 	</array>
 	<key>FAReportIssueURL</key>
 	<string>https://github.com/FuzzyAutocomplete/FuzzyAutocompletePlugin/issues</string>


### PR DESCRIPTION
Support for Xcode 6.3.2.

I briefly tested the plugin with Xcode 6.3.2 and it looks ok!