### PR TITLE
Fixing crash through nil string in attributed string initializer

### DIFF
--- a/FuzzyAutocomplete/FATextCompletionListHeaderView.m
+++ b/FuzzyAutocomplete/FATextCompletionListHeaderView.m
@@ -111,7 +111,7 @@
         status = [status stringByAppendingFormat: @" - %.2f ms", 1000 * session.fa_lastFilteringTime];
     }
 
-    NSMutableAttributedString * attributed = [[NSMutableAttributedString alloc] initWithString: status];
+    NSMutableAttributedString * attributed = [[NSMutableAttributedString alloc] initWithString: status ?: @""];
     [attributed addAttribute: NSFontAttributeName value: _boldFont range: NSMakeRange(0, session.fa_filteringQuery.length)];
     [attributed addAttribute: NSForegroundColorAttributeName value: [NSColor controlTextColor] range: NSMakeRange(0, session.fa_filteringQuery.length)];
 


### PR DESCRIPTION
I'm seeing this crash reproducibly when hitting escape while inside an import statement: https://gist.github.com/stigi/42f88e558f1eb42f946646fe725c9fc2

This commit adds some robustness to prevent this and similar crashes. It doesn't attempt to find the root cause though.
